### PR TITLE
Feat/142 provide spendable reveal and reclaim paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ the application.
 To run the docker containers locally;
 
 ```bash
-./build.sh
+build -t mijoco/bridge_api sbtc-bridge-api
 ```
 
 Note the build.sh tags and pushes the containers to mijoco docker hub. This will change for mainnet
@@ -32,8 +32,20 @@ deployment.
 Alternatively, no docker hub, use docker compose directly..
 
 ```bash
-docker-compose build
-docker-compose up -d
+docker rm -f bridge_api_staging
+  source /home/bob/.profile;
+  docker run -d -t -i --name bridge_api_staging -p 3010:3010 \
+  -e TARGET_ENV='linode-staging' \
+  -e btcSchnorrReveal=${BTC_SCHNORR_KEY_REVEAL} \
+  -e btcSchnorrReclaim=${BTC_SCHNORR_KEY_RECLAIM} \
+  -e btcRpcUser=${BTC_RPC_USER} \
+  -e btcRpcPwd=${BTC_RPC_PWD} \
+  -e btcNode=${BTC_NODE} \
+  -e mongoDbUrl=${MONGO_SBTC_URL} \
+  -e mongoDbName=${MONGO_SBTC_DBNAME} \
+  -e mongoUser=${MONGO_SBTC_USER} \
+  -e mongoPwd=${MONGO_SBTC_PWD} \
+  mijoco/bridge_api
 ```
 
 ## Swagger API Docs
@@ -45,16 +57,10 @@ See https://testnet.stx.eco/bridge-api/docs/#/
 Deployment builds, tags and pushes the images and then uses ssh to log on to remote server
 and then pulls the images from docker hub;
 
-```bash
-docker-compose -f docker-compose.yml pull
-docker-compose -f docker-compose.yml up -d
-```
-
 This is automated using the deploy script;
 
 ```bash
-./deploy.sh // for testnet
-./deploy.sh prod // for mainnet
+./deploy-linode.sh
 ```
 
 Note: requires docker hub access and ssh key registered on server. This will change when deployment
@@ -68,6 +74,7 @@ The sBTC Wallet is a taproot wallet with addresses (most recent first);
 - tb1pf74xr0x574farj55t4hhfvv0vpc9mpgerasawmf5zk9suauckugqdppqe8
 
 ## Production Deployment
+
 Note: `docker-compose.yml` is used for production deployment.
 
 - Local build and push of docker images

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -18,6 +18,9 @@ docker rm -f bridge_api
 #source ~/.profile;
 docker run -d -t -i --name bridge_api -p 3010:3010 \
   -e TARGET_ENV='development' \
+  -e btcSchnorrReveal=${BTC_SCHNORR_KEY_REVEAL} \
+  -e btcSchnorrReclaim=${BTC_SCHNORR_KEY_RECLAIM} \
+  -e btcRpcUser=${BTC_RPC_USER} \
   -e btcRpcUser=${BTC_RPC_USER} \
   -e btcRpcPwd=${BTC_RPC_PWD} \
   -e btcNode=${BTC_NODE} \

--- a/deploy-linode.sh
+++ b/deploy-linode.sh
@@ -33,6 +33,8 @@ ssh -i ~/.ssh/id_rsa -p $PORT bob@$SERVER "
   source /home/bob/.profile;
   docker run -d -t -i --name bridge_api_staging -p 3010:3010 \
   -e TARGET_ENV='linode-staging' \
+  -e btcSchnorrReveal=${BTC_SCHNORR_KEY_REVEAL} \
+  -e btcSchnorrReclaim=${BTC_SCHNORR_KEY_RECLAIM} \
   -e btcRpcUser=${BTC_RPC_USER} \
   -e btcRpcPwd=${BTC_RPC_PWD} \
   -e btcNode=${BTC_NODE} \
@@ -46,6 +48,8 @@ docker rm -f bridge_api_production
   source /home/bob/.profile;
   docker run -d -t -i --name bridge_api_production -p 3020:3010 \
   -e TARGET_ENV='production' \
+  -e btcSchnorrReveal=${BTC_SCHNORR_KEY_REVEAL} \
+  -e btcSchnorrReclaim=${BTC_SCHNORR_KEY_RECLAIM} \
   -e btcRpcUser=${BTC_RPC_USER} \
   -e btcRpcPwd=${BTC_RPC_PWD} \
   -e btcNode=${BTC_NODE} \

--- a/sbtc-bridge-api/README.md
+++ b/sbtc-bridge-api/README.md
@@ -1,0 +1,26 @@
+# sbtc-bridge-api
+
+![ci](https://github.com/Trust-Machines/sbtc-bridge-api)
+
+## Introduction
+
+Node Server for sBTC Bridge.
+
+[sbtc.world](https://sbtc.world).
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+## Test
+
+```bash
+npm run test
+```
+
+## Deploy
+
+To be integrated with Google Cloud. Currently builds to Linode via ssh and rsync.

--- a/sbtc-bridge-api/package-lock.json
+++ b/sbtc-bridge-api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@noble/curves": "^1.0.0",
         "@noble/secp256k1": "^1.7.1",
         "@scure/base": "^1.1.1",
         "@scure/bip32": "^1.1.0",
@@ -1578,9 +1579,9 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz",
-      "integrity": "sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
       "funding": [
         {
           "type": "individual",
@@ -1734,6 +1735,21 @@
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0",
         "micro-packed": "~0.3.2"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@noble/curves": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz",
+      "integrity": "sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==",
+      "deprecated": "Upgrade to 1.0.0 or higher for audited version",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "1.3.0"
       }
     },
     "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
@@ -6257,20 +6273,6 @@
         "c32check": "^2.0.0",
         "micro-packed": "^0.3.2",
         "micro-stacks": "^1.2.1"
-      }
-    },
-    "node_modules/sbtc-bridge-lib/node_modules/@noble/curves": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
-      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "dependencies": {
-        "@noble/hashes": "1.3.0"
       }
     },
     "node_modules/sbtc-bridge-lib/node_modules/@noble/hashes": {

--- a/sbtc-bridge-api/package-lock.json
+++ b/sbtc-bridge-api/package-lock.json
@@ -28,7 +28,7 @@
         "morgan": "^1.10.0",
         "node-cron": "^3.0.2",
         "node-fetch": "^2.6.9",
-        "sbtc-bridge-lib": "^1.0.11",
+        "sbtc-bridge-lib": "^1.0.12",
         "swagger-ui-express": "^4.6.2",
         "tsoa": "^5.1.1",
         "uninstall": "^0.0.0"
@@ -6261,9 +6261,9 @@
       }
     },
     "node_modules/sbtc-bridge-lib": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.0.11.tgz",
-      "integrity": "sha512-A9ZOZuf4fREtPYrdLqYLgOhJlBgS6c8qj6DoEew+hnm0ZdwzHnm1xgIuhPszhm2HldpaSUaXMVMXEkMdPwoLkQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/sbtc-bridge-lib/-/sbtc-bridge-lib-1.0.12.tgz",
+      "integrity": "sha512-YLI6MGqKWLBiGt15q/Bbo2WCJYSYVcNBpXOiDltiADszTcjj0Mgjlj76xvYf0qEkQMIYezhdEX5LYNnnjOp3bQ==",
       "dependencies": {
         "@noble/secp256k1": "^2.0.0",
         "@scure/base": "^1.1.1",

--- a/sbtc-bridge-api/package.json
+++ b/sbtc-bridge-api/package.json
@@ -72,7 +72,7 @@
     "morgan": "^1.10.0",
     "node-cron": "^3.0.2",
     "node-fetch": "^2.6.9",
-    "sbtc-bridge-lib": "^1.0.11",
+    "sbtc-bridge-lib": "^1.0.12",
     "swagger-ui-express": "^4.6.2",
     "tsoa": "^5.1.1",
     "uninstall": "^0.0.0"

--- a/sbtc-bridge-api/package.json
+++ b/sbtc-bridge-api/package.json
@@ -53,6 +53,7 @@
     "vitest-fetch-mock": "^0.2.2"
   },
   "dependencies": {
+    "@noble/curves": "^1.0.0",
     "@noble/secp256k1": "^1.7.1",
     "@scure/base": "^1.1.1",
     "@scure/bip32": "^1.1.0",

--- a/sbtc-bridge-api/public/swagger.json
+++ b/sbtc-bridge-api/public/swagger.json
@@ -6,6 +6,29 @@
 		"requestBodies": {},
 		"responses": {},
 		"schemas": {
+			"KeySet": {
+				"properties": {
+					"deposits": {
+						"properties": {
+							"reclaimPubKey": {
+								"type": "string"
+							},
+							"revealPubKey": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"reclaimPubKey",
+							"revealPubKey"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"deposits"
+				],
+				"type": "object"
+			},
 			"FeeEstimateResponse": {
 				"properties": {
 					"feeInfo": {
@@ -185,6 +208,25 @@
 	},
 	"openapi": "3.0.0",
 	"paths": {
+		"/bridge-api/{network}/v1/btc/tx/keys": {
+			"get": {
+				"operationId": "GetKeys",
+				"responses": {
+					"200": {
+						"description": "Ok",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/KeySet"
+								}
+							}
+						}
+					}
+				},
+				"security": [],
+				"parameters": []
+			}
+		},
 		"/bridge-api/{network}/v1/btc/tx/{txid}": {
 			"get": {
 				"operationId": "FetchRawTransaction",

--- a/sbtc-bridge-api/src/lib/bitcoin/rpc_commit.ts
+++ b/sbtc-bridge-api/src/lib/bitcoin/rpc_commit.ts
@@ -19,11 +19,13 @@ async function matchCommitmentIn(txs:Array<any>, peginRequest:PeginRequestI):Pro
   for (const tx of txs) {
     //console.log('scanPeginCommitTransactions: tx: ', tx);
     for (const vout of tx.vout) {
+      const senderAddress = tx.vin[0]?.prevout?.scriptpubkey_address || undefined;
       console.log('matchCommitmentIn: matching: ' + peginRequest.amount + ' to ' + vout.value)
       if (peginRequest.commitTxScript?.address === vout.scriptpubkey_address) {
         const up = {
           tries:  (peginRequest.tries) ? peginRequest.tries + 1 : 1,
           btcTxid: tx.txid,
+          senderAddress,
           status: 2,
           vout: vout
         }

--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -129,7 +129,7 @@ function setOverrides() {
     CONFIG.btcSchnorrReclaim = process.env.BTC_SCHNORR_KEY_RECLAIM as string;
   }
   if (isDev()) {
-    CONFIG.btcNode = '127.0.0.1:18332';
+    //CONFIG.btcNode = '127.0.0.1:18332';
   }
 }
 

--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -1,4 +1,7 @@
 import { env } from "process";
+import dotenv from 'dotenv'
+
+dotenv.config()
 
 const PORT = parseInt(env.PORT || '3010');
 
@@ -11,6 +14,8 @@ const TESTNET_CONFIG = {
   btcNode: 'bitcoind.testnet.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem',
+  btcSchnorrReveal: '',
+  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: PORT,
   network: 'testnet',
@@ -34,6 +39,8 @@ const MAINNET_CONFIG = {
   btcNode: 'bitcoind.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem',
+  btcSchnorrReveal: '',
+  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: PORT,
   network: 'mainnet',
@@ -57,6 +64,8 @@ const DEVNET_CONFIG = {
   btcNode: 'bitcoind.testnet.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem', 
+  btcSchnorrReveal: '',
+  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: 3010,
   walletPath: '/wallet/descwallet',
@@ -80,6 +89,8 @@ const LINODE_CONFIG = {
   btcNode: 'bitcoind.testnet.stacks.co',
   btcRpcUser: 'blockstack',
   btcRpcPwd: 'blockstacksystem',
+  btcSchnorrReveal: '',
+  btcSchnorrReclaim: '',
   host: 'http://localhost',
   port: 3010,
   walletPath: '/wallet/SBTC-0003',
@@ -94,7 +105,7 @@ const LINODE_CONFIG = {
   publicAppVersion: '1.0.0',
 }
 
-let CONFIG: { mongoDbUrl: string; mongoUser: string; mongoPwd: string; mongoDbName: string; btcNode: string; btcRpcUser: string; btcRpcPwd: string; host: string; port: number; walletPath: string; network: string; sbtcContractId: string; stacksApi: string; stacksExplorerUrl: string; bitcoinExplorerUrl: string; mempoolUrl: string; blockCypherUrl: string; publicAppName: string; publicAppVersion: string; };
+let CONFIG: { mongoDbUrl: string; mongoUser: string; mongoPwd: string; mongoDbName: string; btcNode: string; btcRpcUser: string; btcRpcPwd: string; btcSchnorrReveal: string; btcSchnorrReclaim: string; host: string; port: number; walletPath: string; network: string; sbtcContractId: string; stacksApi: string; stacksExplorerUrl: string; bitcoinExplorerUrl: string; mempoolUrl: string; blockCypherUrl: string; publicAppName: string; publicAppVersion: string; };
 
 export function setConfigOnStart() {
 	if (isDev()) CONFIG = DEVNET_CONFIG;
@@ -107,22 +118,18 @@ export function setConfigOnStart() {
 function setOverrides() {
   if (isDev() || isLinode()) {
     // Not Trust Machines Kit - so override the btc connection params with platform values;
-    if (process.env.mongoDbUrl) CONFIG.mongoDbUrl = process.env.mongoDbUrl;
-    if (process.env.mongoDbName) CONFIG.mongoDbName = process.env.mongoDbName;
-    if (process.env.mongoUser) CONFIG.mongoUser = process.env.mongoUser;
-    if (process.env.mongoPwd) CONFIG.mongoPwd = process.env.mongoPwd;
-    if (process.env.btcNode) CONFIG.btcNode = process.env.btcNode;
-    if (process.env.btcRpcUser) CONFIG.btcRpcUser = process.env.btcRpcUser;
-    if (process.env.btcRpcPwd) CONFIG.btcRpcPwd = process.env.btcRpcPwd;
+    CONFIG.mongoDbUrl = process.env.MONGO_SBTC_URL as string;
+    CONFIG.mongoDbName = process.env.MONGO_SBTC_DBNAME as string;
+    CONFIG.mongoUser = process.env.MONGO_SBTC_USER as string;
+    CONFIG.mongoPwd = process.env.MONGO_SBTC_PWD as string;
+    CONFIG.btcNode = process.env.BTC_NODE as string;
+    CONFIG.btcRpcUser = process.env.BTC_RPC_USER as string;
+    CONFIG.btcRpcPwd = process.env.BTC_RPC_PWD as string;
+    CONFIG.btcSchnorrReveal = process.env.BTC_SCHNORR_KEY_REVEAL as string;
+    CONFIG.btcSchnorrReclaim = process.env.BTC_SCHNORR_KEY_RECLAIM as string;
   }
   if (isDev()) {
-    //CONFIG.mongoUser = '';
-    //CONFIG.mongoPwd = '';
-    //CONFIG.mongoDbUrl = '';
-    //CONFIG.mongoDbName = '';
-    //CONFIG.btcNode = '';
-    //CONFIG.btcRpcUser = '';
-    //CONFIG.btcRpcPwd = '';
+    CONFIG.btcNode = '127.0.0.1:18332';
   }
 }
 

--- a/sbtc-bridge-api/src/lib/config.ts
+++ b/sbtc-bridge-api/src/lib/config.ts
@@ -128,9 +128,6 @@ function setOverrides() {
     CONFIG.btcSchnorrReveal = process.env.BTC_SCHNORR_KEY_REVEAL as string;
     CONFIG.btcSchnorrReclaim = process.env.BTC_SCHNORR_KEY_RECLAIM as string;
   }
-  if (isDev()) {
-    //CONFIG.btcNode = '127.0.0.1:18332';
-  }
 }
 
 function isDev() {

--- a/sbtc-bridge-api/src/lib/data/db_models.ts
+++ b/sbtc-bridge-api/src/lib/data/db_models.ts
@@ -7,7 +7,7 @@ let peginRequest:Collection;
   
 export async function connect() {
 	const uri = `mongodb+srv://${getConfig().mongoUser}:${getConfig().mongoPwd}@${getConfig().mongoDbUrl}/?retryWrites=true&w=majority`;
-	console.log("Mongo: " + uri);
+	//console.log("Mongo: " + uri);
 
 	// The MongoClient is the object that references the connection to our
 	// datastore (Atlas, for example)

--- a/sbtc-bridge-api/src/routes/index.ts
+++ b/sbtc-bridge-api/src/routes/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { TransactionController, BlocksController, DefaultController, WalletController } from "../controllers/BitcoinRPCController.js";
 import { SbtcWalletController, DepositsController } from "../controllers/StacksRPCController.js";
 import { ConfigController } from "../controllers/ConfigController.js";
-import type { PeginRequestI } from 'sbtc-bridge-lib';
+import type { PeginRequestI, WrappedPSBT } from 'sbtc-bridge-lib';
 
 const router = express.Router();
 
@@ -58,7 +58,6 @@ router.get("/bridge-api/:network/v1/btc/wallet/validate/:address", async (req, r
 
 router.post("/bridge-api/:network/v1/btc/wallet/walletprocesspsbt", async (req, res, next) => {
   try {
-    console.log('/btc/tx/sendrawtx', req.body);
     const tx = req.body;
     const controller = new WalletController();
     const response = await controller.processPsbt(tx.hex);
@@ -104,6 +103,40 @@ router.get("/bridge-api/:network/v1/btc/wallet/listwallets", async (req, res, ne
     return res.send(response);
   } catch (error) {
     next(error)
+  }
+});
+
+router.get("/bridge-api/:network/v1/btc/tx/keys", async (req, res, next) => {
+  try {
+    const controller = new TransactionController();
+    const response = await controller.getKeys();
+    return res.send(response);
+  } catch (error) { // manually catching
+    next(error) // passing to default middleware error handler
+  }
+});
+
+router.post("/bridge-api/:network/v1/btc/tx/sign", async (req, res, next) => {
+  try {
+    const wrappedPsbt:WrappedPSBT = req.body;
+    console.log('wrappedPsbt 0: ', req.body);
+    const controller = new TransactionController();
+    const response = await controller.sign(wrappedPsbt);
+    return res.send(response);
+  } catch (error) { // manually catching
+    next(error) // passing to default middleware error handler
+  }
+});
+
+router.post("/bridge-api/:network/v1/btc/tx/signAndBroadcast", async (req, res, next) => {
+  try {
+    const wrappedPsbt:WrappedPSBT = req.body;
+    console.log('wrappedPsbt: ', wrappedPsbt);
+    const controller = new TransactionController();
+    const response = await controller.signAndBroadcast(wrappedPsbt);
+    return res.send(response);
+  } catch (error) { // manually catching
+    next(error) // passing to default middleware error handler
   }
 });
 

--- a/sbtc-bridge-api/tests/config.test.ts
+++ b/sbtc-bridge-api/tests/config.test.ts
@@ -12,7 +12,7 @@ describe('bitcoin rpc suite - requires bitcoin core running on testnet', () => {
 
   it.concurrent('Check estimateSmartFee() returns correct fees', async () => {
     //console.log('walletInfoResult: ', util.inspect(result, false, null, true /* enable colors */));
-    expect(getConfig().btcNode).equals('bitcoind.testnet.stacks.co');
+    expect(getConfig().btcNode).equals('host.docker.internal:18332');
   })
 
 })

--- a/sbtc-bridge-lib/README.md
+++ b/sbtc-bridge-lib/README.md
@@ -1,0 +1,29 @@
+# sbtc-bridge-lib
+
+![ci](https://github.com/Trust-Machines/sbtc-bridge-web)
+
+
+## Introduction
+
+Library and utility functions for the sBTC Bridge.
+
+[sbtc.world](https://sbtc.world).
+
+## Build
+
+```bash
+npm install
+npx tsc
+```
+
+## Test
+
+```bash
+npm run test
+```
+
+## Publish
+
+```bash
+npm publish
+```

--- a/sbtc-bridge-lib/package.json
+++ b/sbtc-bridge-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sbtc-bridge-lib",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Library for sBTC Bridge web client and API apps ",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/sbtc-bridge-lib/src/index.ts
+++ b/sbtc-bridge-lib/src/index.ts
@@ -14,7 +14,9 @@ import {
     getStacksAddressFromSignature,
     parseSbtcWalletAddress,
     parseOutputs,
-    readDepositValue
+    readDepositValue,
+    fromStorable,
+    toStorable
 } from './payload_utils.js'
 export {
     MAGIC_BYTES_TESTNET,
@@ -32,7 +34,9 @@ export {
     getStacksAddressFromSignature,
     parseSbtcWalletAddress,
     parseOutputs,
-    readDepositValue
+    readDepositValue,
+    fromStorable,
+    toStorable
 } 
 
 import {
@@ -68,7 +72,9 @@ import type {
     UTXO,
     payloadType,
     withdrawalPayloadType,
-    depositPayloadType
+    depositPayloadType,
+    KeySet,
+    WrappedPSBT
 } from './types/sbtc_types.js'
 export type {
     PeginRequestI, 
@@ -85,5 +91,7 @@ export type {
     UTXO,
     payloadType,
     withdrawalPayloadType,
-    depositPayloadType
+    depositPayloadType,
+    KeySet,
+    WrappedPSBT
 }

--- a/sbtc-bridge-lib/src/payload_utils.ts
+++ b/sbtc-bridge-lib/src/payload_utils.ts
@@ -295,3 +295,73 @@ enum StacksNetworkVersion {
 	testnetP2PKH = 26, // 'T'   TestnetSingleSig
 	testnetP2SH = 21, // 'N'    TestnetMultiSig
 }
+
+export function fromStorable(script:any) {
+	if (typeof script.tweakedPubkey === 'string') return script
+	return codifyScript(script, true)
+}
+  
+export function toStorable(script:any) {
+	//const copied = JSON.parse(JSON.stringify(script));
+	return codifyScript(script, false)
+}
+  
+  function codifyScript(script:any, asString:boolean) {
+	return {
+	  address: script.address,
+	  script: codify(script.script, asString),
+	  paymentType: (script.type) ? script.type : script.paymentType,
+	  witnessScript: codify(script.witnessScript, asString),
+	  redeemScript: codify(script.redeemScript, asString),
+	  leaves: (script.leaves) ? codifyLeaves(script.leaves, asString) : undefined,
+	  tapInternalKey: codify(script.tapInternalKey, asString),
+	  tapLeafScript: (script.tapLeafScript) ? codifyTapLeafScript(script.tapLeafScript, asString) : undefined,
+	  tapMerkleRoot: codify(script.tapMerkleRoot, asString),
+	  tweakedPubkey: codify(script.tweakedPubkey, asString),
+	}
+  
+  }
+  
+  function codifyTapLeafScript(tapLeafScript:any, asString:boolean) {
+	if (tapLeafScript[0]) {
+	  const level0 = tapLeafScript[0]
+	  if (level0[0]) tapLeafScript[0][0].internalKey = codify(tapLeafScript[0][0].internalKey, asString)
+	  if (level0[0]) tapLeafScript[0][0].merklePath[0] = codify(tapLeafScript[0][0].merklePath[0], asString)
+	  if (level0[1]) tapLeafScript[0][1] = codify(tapLeafScript[0][1], asString)
+	}
+	if (tapLeafScript[1]) {
+	  const level1 = tapLeafScript[1]
+	  if (level1[0]) tapLeafScript[1][0].internalKey = codify(tapLeafScript[1][0].internalKey, asString)
+	  if (level1[0]) tapLeafScript[1][0].merklePath[0] = codify(tapLeafScript[1][0].merklePath[0], asString)
+	  if (level1[1]) tapLeafScript[1][1] = codify(tapLeafScript[1][1], asString)
+	}
+	return tapLeafScript;
+  }
+  
+  function codify (arg:unknown, asString:boolean) {
+	if (!arg) return;
+	if (typeof arg === 'string') {
+	  return hex.decode(arg)
+	} else {
+	  return hex.encode(arg as Uint8Array)
+	}
+  }
+  function codifyLeaves(leaves:any, asString:boolean) {
+	if (leaves[0]) {
+	  const level1 = leaves[0]
+	  if (level1.controlBlock) leaves[0].controlBlock = codify(leaves[0].controlBlock, asString)
+	  if (level1.hash) leaves[0].hash = codify(leaves[0].hash, asString)
+	  if (level1.script) leaves[0].script = codify(leaves[0].script, asString)
+	  if (level1.path && level1.path[0]) leaves[0].path[0] = codify(leaves[0].path[0], asString)
+	}
+	if (leaves[1]) {
+	  const level1 = leaves[1]
+	  if (level1.controlBlock) leaves[1].controlBlock = codify(leaves[1].controlBlock, asString)
+	  if (level1.hash) leaves[1].hash = codify(leaves[1].hash, asString)
+	  if (level1.script) leaves[1].script = codify(leaves[1].script, asString)
+	  if (level1.path && level1.path[0]) leaves[1].path[0] = codify(leaves[1].path[0], asString)
+	}
+	return leaves;
+  }
+  
+  

--- a/sbtc-bridge-lib/src/types/sbtc_types.ts
+++ b/sbtc-bridge-lib/src/types/sbtc_types.ts
@@ -36,6 +36,7 @@ export type SbtcBalance = {
 };
 export type PeginRequestI = {
   _id?:string;
+  originator: string;
   status: number;
   tries?: number;
 	updated?: number;
@@ -46,12 +47,18 @@ export type PeginRequestI = {
   btcTxid?: string;
   senderAddress?: string;
   fromBtcAddress: string;
-  revealPub: string;
-  reclaimPub: string;
+  reveal?: RevealOrReclaim;
+  reclaim?: RevealOrReclaim;
+  revealPub?: string;
+  reclaimPub?: string;
   stacksAddress: string;
   sbtcWalletAddress: string;
   commitTxScript?: PeginScriptI;
   vout?: VoutI;
+}
+export type RevealOrReclaim = {
+  btcTxid?: string;
+  signedPsbtHex?: string;
 }
 export type PeginScriptI = {
   address?: string;
@@ -85,12 +92,9 @@ export type PegInData = {
 
 export type CommitKeysI = {
   fromBtcAddress: string;
-  reveal: string;
+  sbtcWalletAddress: string;
   revealPub: string;
-  revealPrv?: string;
-  reclaim: string;
   reclaimPub: string;
-  reclaimPrv?: string;
   stacksAddress: string;
 };
 
@@ -160,3 +164,16 @@ export type depositPayloadType = {
   revealFee: number;
   amountSats: number;
 };
+export type KeySet = {
+  deposits: {
+    revealPubKey: string;
+    reclaimPubKey: string;
+  }
+}
+export type WrappedPSBT = {
+  depositId: string;
+  txtype: string;
+  broadcastResult?: any;
+  signedTransaction?: string;
+  signedPsbt?: string;
+}

--- a/sbtc-bridge-lib/src/wallet_utils.ts
+++ b/sbtc-bridge-lib/src/wallet_utils.ts
@@ -55,12 +55,13 @@ export function getTestAddresses (network:string):CommitKeysI {
 	const net = (network === 'testnet') ? btc.TEST_NETWORK : btc.NETWORK;
 	return {
 		fromBtcAddress: btc.getAddress('tr', hex.decode(testWallets[0].privateKey), net) as string,
-		reveal: btc.getAddress('tr', hex.decode(testWallets[0].privateKey), net) as string,
+		sbtcWalletAddress: sbtcWallets[0].sbtcAddress,
+		//reveal: btc.getAddress('tr', hex.decode(testWallets[0].privateKey), net) as string,
 		revealPub: hex.encode(schnorr.getPublicKey(testWallets[0].privateKey) as Uint8Array),
-		revealPrv: testWallets[0].privateKey,
-		reclaim: btc.getAddress('tr', hex.decode(testWallets[1].privateKey), net) as string,
+		//revealPrv: testWallets[0].privateKey,
+		//reclaim: btc.getAddress('tr', hex.decode(testWallets[1].privateKey), net) as string,
 		reclaimPub: hex.encode(schnorr.getPublicKey(testWallets[1].privateKey) as Uint8Array),
-		reclaimPrv: testWallets[1].privateKey,
+		//reclaimPrv: testWallets[1].privateKey,
 		stacksAddress: (network === 'testnet') ? 'ST1RBP62PR532FWVP7JRGC9SVFKKHD1JYK23KYNN0' : 'unsupported'
 	}
 }

--- a/sbtc-bridge-lib/tests/payload.data.ts
+++ b/sbtc-bridge-lib/tests/payload.data.ts
@@ -9,6 +9,7 @@ export const commit1:PeginRequestI = {
   mode: 'op_drop',
   requestType: 'wrap',
   wallet: "p2tr(TAPROOT_UNSPENDABLE_KEY, [{ script: Script.encode([data, 'DROP', revealPubK, 'CHECKSIG']) }, { script: Script.encode([reclaimPubKey, 'CHECKSIG']) }], this.net, true)",
+  originator: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5',
   stacksAddress: 'ST1R1061ZT6KPJXQ7PAXPFB6ZAZ6ZWW28G8HXK9G5',
   sbtcWalletAddress: 'tb1pf74xr0x574farj55t4hhfvv0vpc9mpgerasawmf5zk9suauckugqdppqe8',
   commitTxScript: {


### PR DESCRIPTION
Moves the key pairs for the embedded taproot scripts server side. Having them as custodial keys means

a) the bridge can generate test reveal transaction
b) the bridge can refund users bitcoin if no spent by the reveal